### PR TITLE
Design tweaks — search bars, faucet grid, button states

### DIFF
--- a/src/components/LiquidityPoolsTable.tsx
+++ b/src/components/LiquidityPoolsTable.tsx
@@ -62,14 +62,14 @@ const LiquidityPoolsTable = ({
             placeholder='Search by token name or pair...'
             value={search}
             onChange={e => setSearch(e.target.value)}
-            className='pl-9 rounded-lg bg-muted/50 border-muted-foreground/20'
+            className='pl-9 h-12 rounded-lg bg-muted/50 border-muted-foreground/20'
           />
         </div>
         <div className='flex gap-2'>
           <Button
             variant='outline'
             size='sm'
-            className={`rounded-lg ${
+            className={`h-12 rounded-lg ${
               poolFilter === 'hot'
                 ? 'bg-primary/10 border-primary text-primary'
                 : 'bg-muted/50 border-muted-foreground/20'
@@ -82,7 +82,7 @@ const LiquidityPoolsTable = ({
           <Button
             variant='outline'
             size='sm'
-            className={`rounded-lg ${
+            className={`h-12 rounded-lg ${
               poolFilter === 'new'
                 ? 'bg-primary/10 border-primary text-primary'
                 : 'bg-muted/50 border-muted-foreground/20'
@@ -95,7 +95,7 @@ const LiquidityPoolsTable = ({
           <Button
             variant='outline'
             size='sm'
-            className={`rounded-lg ${
+            className={`h-12 rounded-lg ${
               poolFilter === 'stables'
                 ? 'bg-primary/10 border-primary text-primary'
                 : 'bg-muted/50 border-muted-foreground/20'

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva } from 'class-variance-authority';
 import * as React from 'react';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97] [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -162,7 +162,7 @@ function Explore() {
                 />
               ))
               : (
-                <div className='col-span-full rounded-xl border border-dashed border-muted-foreground/30 bg-muted/20 p-8 text-center text-muted-foreground text-sm'>
+                <div className='col-span-full rounded-xl border border-dashed border-muted-foreground/30 bg-muted/20 py-16 px-8 text-center text-muted-foreground text-sm'>
                   No positions yet. Add liquidity in High frequency pools below.
                 </div>
               )}
@@ -170,9 +170,15 @@ function Explore() {
         </section>
 
         <section id='high-frequency-pools'>
-          <h2 className='text-2xl font-bold font-cal-sans text-foreground mb-4'>
-            High frequency pools
-          </h2>
+          <div className='flex items-center gap-2 mb-4'>
+            <h2 className='text-2xl font-bold font-cal-sans text-foreground'>
+              High frequency pools
+            </h2>
+            <span className='inline-flex items-center gap-1.5 rounded-full bg-foreground/5 px-2.5 py-1 text-[11px] font-medium text-muted-foreground'>
+              <span className='h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse' />
+              Under construction
+            </span>
+          </div>
           <LiquidityPoolsTable
             poolsInfo={poolsInfo}
             poolBalances={poolBalances}
@@ -203,7 +209,7 @@ function Explore() {
               placeholder='Search by pool id (bech32 or 0x hex)…'
               value={communityPoolsSearch}
               onChange={e => setCommunityPoolsSearch(e.target.value)}
-              className='pl-9 rounded-lg bg-muted/50 border-muted-foreground/20'
+              className='pl-9 h-12 rounded-lg bg-muted/50 border-muted-foreground/20'
             />
           </div>
           <XykPoolTable search={communityPoolsSearch} />

--- a/src/pages/Faucet.tsx
+++ b/src/pages/Faucet.tsx
@@ -164,36 +164,34 @@ function Faucet() {
       <meta name='twitter:title' content='Faucet - ZoroSwap | DeFi on Miden' />
       <meta name='twitter:description' content='Testnet faucet for the Zoro Swap AMM.' />
       <Header />
-      <main className='flex-1 flex items-center justify-center p-3'>
-        <div className='w-full max-w-[495px]'>
-          <div>
-            {Object.values(tokens).map((token, index) => {
+      <main className='flex-1 w-full max-w-5xl mx-auto px-6 py-8'>
+          <div className='text-center mb-10'>
+            <h1 className='text-3xl font-bold font-cal-sans text-foreground mb-2'>
+              Testnet Faucet
+            </h1>
+            <p className='text-sm text-muted-foreground'>
+              Request test tokens to start swapping and providing liquidity on Miden testnet.
+            </p>
+          </div>
+          <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6'>
+            {Object.values(tokens).map((token) => {
               const status = mintStatuses[token.faucetIdBech32];
 
               if (!token || !status) return null;
-              const lineBetween = index > 0
-                ? <div className='border border-bottom-0 border-dashed my-6 opacity-50' />
-                : null;
 
               return (
                 <Fragment key={token.faucetIdBech32}>
-                  {lineBetween}
+                  <div className='flex flex-col'>
                   <Card
-                    key={token.symbol}
-                    className='rounded-xl transition-all duration-200 hover:border-orange-200/10 mb-4'
+                    className='rounded-xl rounded-b-none border-b-0 transition-all duration-200 hover:border-orange-200/10'
                   >
-                    <CardContent className='p-4 sm:p-6 flex gap-1 flex-col items-center'>
-                      <AssetIcon symbol={token.symbol} />
+                    <CardContent className='p-6 sm:p-8 flex gap-2 flex-col items-center'>
+                      <AssetIcon symbol={token.symbol} size={48} />
                       <h3 className='text-md sm:text-lg font-semibold'>
                         Test {token.name}
                       </h3>
-                      <div className='text-xs text-muted-foreground overflow-hidden'>
-                        <span className='hidden sm:inline'>
-                          {token.faucetIdBech32}
-                        </span>
-                        <span className='sm:hidden break-all'>
-                          {token.faucetIdBech32}
-                        </span>
+                      <div className='text-[10px] text-muted-foreground text-center'>
+                        {token.faucetIdBech32}
                       </div>
                     </CardContent>
                   </Card>
@@ -201,7 +199,7 @@ function Faucet() {
                     <Button
                       onClick={() => requestTokens(token.faucetIdBech32)}
                       disabled={isButtonDisabled(status)}
-                      className='w-full h-8 sm:h-12 bg-primary hover:bg-orange-700 text-white font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+                      className='w-full h-14 rounded-none rounded-b-xl bg-primary hover:bg-orange-700 text-white text-sm sm:text-lg font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
                     >
                       {status.isLoading && (
                         <Loader2 className='w-4 h-4 mr-2 animate-spin' />
@@ -210,7 +208,7 @@ function Faucet() {
                     </Button>
                   )}
                   {!connected && (
-                    <UnifiedWalletButton className='!font-bold !p-5 w-full !font-semibold !font-sans h-full !rounded-xl !text-sm sm:!text-lg !bg-primary !text-primary-foreground hover:!bg-primary/90 !border-none !text-center !flex !items-center !justify-center' />
+                    <UnifiedWalletButton className='!font-bold !p-5 w-full !font-semibold !font-sans h-full !rounded-none !rounded-b-xl !text-sm sm:!text-lg !bg-primary !text-primary-foreground hover:!bg-primary/90 !border-none !text-center !flex !items-center !justify-center' />
                   )}
                   <div
                     className={`overflow-hidden transition-all duration-300 ease-out ${
@@ -240,11 +238,12 @@ function Faucet() {
                       </div>
                     )}
                   </div>
+                  </div>
                 </Fragment>
               );
             })}
           </div>
-          <div className='pt-8 pb-2 sm:pb-0 flex sm:justify-start justify-center sm:items-start'>
+          <div className='pt-8 pb-2 sm:pb-0 flex justify-center'>
             <Link to='/'>
               <Button
                 variant='secondary'
@@ -255,7 +254,6 @@ function Faucet() {
               </Button>
             </Link>
           </div>
-        </div>
       </main>
       <Footer />
     </div>

--- a/src/pages/Launchpad.tsx
+++ b/src/pages/Launchpad.tsx
@@ -156,20 +156,14 @@ export default function Launchpad() {
       <title>Launchpad - ZoroSwap | DeFi on Miden</title>
       <meta name='description' content='Launch a new token on Miden testnet.' />
       <Header />
-      <main className='flex-1 w-full max-w-xl mx-auto px-4 sm:px-6 py-8 sm:py-12'>
-        <Link
-          to='/'
-          className={`inline-flex items-center gap-2 ${bodyClass} hover:text-foreground transition-colors mb-8`}
-        >
-          <ArrowLeft className='h-4 w-4 shrink-0' />
-          Back to Swap
-        </Link>
+      <main className='flex-1 w-full max-w-5xl mx-auto px-6 py-8'>
+        <div className='max-w-xl mx-auto'>
 
         <div className='text-center mb-8 sm:mb-10'>
           <h1 className='text-2xl sm:text-3xl font-cal-sans font-bold text-foreground tracking-tight'>
             Token launchpad
           </h1>
-          <p className={`mt-3 max-w-md mx-auto ${bodyClass}`}>
+          <p className={`mt-3 ${bodyClass}`}>
             Deploy a new faucet token on Miden and mint the whole initial supply to your
             account. You will need to consume the tokens in your wallet.
           </p>
@@ -428,6 +422,18 @@ export default function Launchpad() {
             </div>
           </CardContent>
         </Card>
+        <div className='pt-8 pb-2 flex justify-center'>
+          <Link to='/'>
+            <Button
+              variant='secondary'
+              size='sm'
+              className='text-xs sm:text-sm text-muted-foreground hover:text-foreground transition-colors'
+            >
+              ← Back to Swap
+            </Button>
+          </Link>
+        </div>
+        </div>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- **Explore page**: taller search bars (48px), matching filter button heights, "Under construction" badge on High frequency pools, taller empty positions container
- **Faucet page**: horizontal 3-column card grid layout with fused button style, added page heading + description, consistent content alignment
- **Launchpad page**: matched content start height with other pages, moved "Back to Swap" to bottom
- **Global**: added `active:scale(0.97)` press feedback to base button component for tactile responsiveness across all pages

## Test plan
- [ ] Verify search bars and filter buttons align on Explore page
- [ ] Check Faucet page grid layout on desktop and mobile
- [ ] Confirm button press feedback feels responsive across all pages
- [ ] Verify Launchpad content alignment matches Faucet/Explore

🤖 Generated with [Claude Code](https://claude.com/claude-code)